### PR TITLE
dayRightclick modified for FC 2.5+

### DIFF
--- a/fullcalendar-rightclick.js
+++ b/fullcalendar-rightclick.js
@@ -34,8 +34,8 @@
 						'.fc-bgevent-skeleton'
 					);
 					if (fcContainer.length) {
-						that.coordMap.build();
-						var cell = that.coordMap.getCell(ev.pageX, ev.pageY);
+						that.prepareHits();
+                                                var cell = that.queryHit(ev.pageX, ev.pageY);
 						if (cell)
 							return that.trigger(
 								'dayRightclick', null, cell.start, ev


### PR DESCRIPTION
dayRightclick() wasn't working for me with FC 2.5.0 (and now 2.6.0). I was seeing console.log errors about a missing 'build' function. It looks like an FC grid refactor removed coordMap. I dug in and believe I've squared it away. At least the event is firing and I can catch it.
